### PR TITLE
Unit, install, and file options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +92,16 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "io-lifetimes"
@@ -137,6 +156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
 name = "podlet"
 version = "0.1.0"
 dependencies = [
@@ -144,6 +169,7 @@ dependencies = [
  "ipnet",
  "shlex",
  "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -266,10 +292,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775c11906edafc97bc378816b94585fbd9a054eabaf86fdd0ced94af449efab7"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,36 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +43,12 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -52,6 +88,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +136,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +153,12 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "heck"
@@ -102,6 +181,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "io-lifetimes"
@@ -132,6 +217,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +233,30 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -156,16 +271,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
 name = "podlet"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "color-eyre",
  "ipnet",
  "shlex",
  "thiserror",
@@ -215,6 +343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+
+[[package]]
 name = "rustix"
 version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +360,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -292,6 +435,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +458,48 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -337,6 +532,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 clap = { version = "4.1.8", features = ["derive"] }
+color-eyre = "0.6.2"
 ipnet = "2.7.2"
 shlex = "1.1.0"
 thiserror = "1.0.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ clap = { version = "4.1.8", features = ["derive"] }
 ipnet = "2.7.2"
 shlex = "1.1.0"
 thiserror = "1.0.40"
+url = "2.3.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,10 @@ use std::{
 };
 
 use clap::{Parser, Subcommand};
-use color_eyre::eyre::{self, Context};
+use color_eyre::{
+    eyre::{self, Context},
+    Help,
+};
 
 use self::{
     container::Container, install::Install, kube::Kube, network::Network, service::Service,
@@ -81,7 +84,9 @@ impl Cli {
     pub fn print_or_write_file(&self) -> eyre::Result<()> {
         if self.file.is_some() {
             let path = self.file_path()?;
-            let mut file = File::create(&path)?;
+            let mut file = File::create(&path)
+                .wrap_err("Failed to create/open file")
+                .suggestion("Make sure you have write permissions for the file")?;
             write!(file, "{self}").wrap_err("Failed to write to file")?;
             println!("Wrote to file: {}", path.display());
             Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 mod container;
+mod install;
 mod kube;
 mod network;
 mod service;
@@ -18,8 +19,8 @@ use clap::{Parser, Subcommand};
 use color_eyre::eyre::{self, Context};
 
 use self::{
-    container::Container, kube::Kube, network::Network, service::Service, unit::Unit,
-    volume::Volume,
+    container::Container, install::Install, kube::Kube, network::Network, service::Service,
+    unit::Unit, volume::Volume,
 };
 
 #[allow(clippy::option_option)]
@@ -51,6 +52,10 @@ pub struct Cli {
     #[command(flatten)]
     unit: Unit,
 
+    /// The \[Install\] section
+    #[command(flatten)]
+    install: Install,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -62,7 +67,13 @@ impl Display for Cli {
         }
 
         let Commands::Podman { command } = &self.command;
-        write!(f, "{command}")
+        write!(f, "{command}")?;
+
+        if self.install.install {
+            write!(f, "\n{}", &self.install)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,19 +2,37 @@ mod container;
 mod kube;
 mod network;
 mod service;
+mod unit;
 mod volume;
 
 use std::{borrow::Cow, fmt::Display};
 
 use clap::{Parser, Subcommand};
 
-use self::{container::Container, kube::Kube, network::Network, service::Service, volume::Volume};
+use self::{
+    container::Container, kube::Kube, network::Network, service::Service, unit::Unit,
+    volume::Volume,
+};
 
 #[derive(Parser, Debug, Clone, PartialEq)]
 #[command(author, version, about)]
 pub struct Cli {
+    #[command(flatten)]
+    unit: Unit,
+
     #[command(subcommand)]
-    pub command: Commands,
+    command: Commands,
+}
+
+impl Display for Cli {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if !self.unit.is_empty() {
+            writeln!(f, "{}", &self.unit)?;
+        }
+
+        let Commands::Podman { command } = &self.command;
+        write!(f, "{command}")
+    }
 }
 
 #[derive(Subcommand, Debug, Clone, PartialEq)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,7 @@ use self::{
 #[derive(Parser, Debug, Clone, PartialEq)]
 #[command(author, version, about)]
 pub struct Cli {
+    /// The \[Unit\] section
     #[command(flatten)]
     unit: Unit,
 
@@ -65,6 +66,7 @@ pub enum PodmanCommands {
     /// For details on options see:
     /// https://docs.podman.io/en/latest/markdown/podman-kube-play.1.html
     Kube {
+        /// The \[Kube\] section
         #[command(subcommand)]
         kube: Kube,
     },
@@ -74,6 +76,7 @@ pub enum PodmanCommands {
     /// For details on options see:
     /// https://docs.podman.io/en/latest/markdown/podman-network-create.1.html
     Network {
+        /// The \[Network\] section
         #[command(subcommand)]
         network: Network,
     },
@@ -83,6 +86,7 @@ pub enum PodmanCommands {
     /// For details on options see:
     /// https://docs.podman.io/en/latest/markdown/podman-volume-create.1.html
     Volume {
+        /// The \[Volume\] section
         #[command(subcommand)]
         volume: Volume,
     },

--- a/src/cli/container/podman.rs
+++ b/src/cli/container/podman.rs
@@ -6,7 +6,7 @@ use std::{
 use clap::{ArgAction, Args};
 
 #[allow(clippy::struct_excessive_bools, clippy::module_name_repetitions)]
-#[derive(Args, Debug, Clone, PartialEq)]
+#[derive(Args, Default, Debug, Clone, PartialEq)]
 pub struct PodmanArgs {
     /// Add a custom host-to-IP mapping
     ///

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -5,7 +5,7 @@ use clap::{Args, ValueEnum};
 use crate::cli::escape_spaces_join;
 
 #[allow(clippy::module_name_repetitions)]
-#[derive(Args, Debug, Clone, PartialEq)]
+#[derive(Args, Default, Debug, Clone, PartialEq)]
 pub struct QuadletOptions {
     /// Add Linux capabilities
     ///
@@ -37,7 +37,7 @@ pub struct QuadletOptions {
     ///
     /// Converts to "ContainerName=NAME"
     #[arg(long)]
-    name: Option<String>,
+    pub name: Option<String>,
 
     /// Drop Linux capability from the default podman capability set
     ///
@@ -192,7 +192,7 @@ pub struct QuadletOptions {
     /// Control sd-notify behavior
     ///
     /// If `container`, converts to "Notify=true"
-    #[arg(long, value_enum, default_value_t = Notify::Conmon)]
+    #[arg(long, value_enum, default_value_t)]
     sdnotify: Notify,
 
     /// The rootfs to use for the container
@@ -272,6 +272,12 @@ pub struct QuadletOptions {
 enum Notify {
     Conmon,
     Container,
+}
+
+impl Default for Notify {
+    fn default() -> Self {
+        Self::Conmon
+    }
 }
 
 impl Display for QuadletOptions {

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -1,0 +1,55 @@
+use std::fmt::Display;
+
+use clap::Args;
+
+use crate::cli::escape_spaces_join;
+
+#[derive(Args, Debug, Clone, PartialEq)]
+pub struct Install {
+    /// Add an [Install] section to the unit
+    ///
+    /// By default, if the --wanted-by and --required-by options are not used,
+    /// the section will have "WantedBy=default.target".
+    #[arg(short, long)]
+    pub install: bool,
+
+    /// Add (weak) parent dependencies to the unit
+    ///
+    /// Requires the --install option
+    ///
+    /// Converts to "WantedBy=WANTED_BY"
+    ///
+    /// Can be specified multiple times
+    #[arg(long, requires = "install")]
+    wanted_by: Vec<String>,
+
+    /// Similar to --wanted-by, but adds stronger parent dependencies
+    ///
+    /// Requires the --install option
+    ///
+    /// Converts to "RequiredBy=REQUIRED_BY"
+    ///
+    /// Can be specified multiple times
+    #[arg(long, requires = "install")]
+    required_by: Vec<String>,
+}
+
+impl Display for Install {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "[Install]")?;
+
+        if self.wanted_by.is_empty() && self.required_by.is_empty() {
+            writeln!(f, "WantedBy=default.target")?;
+        }
+
+        if !self.wanted_by.is_empty() {
+            writeln!(f, "WantedBy={}", escape_spaces_join(&self.wanted_by))?;
+        }
+
+        if !self.required_by.is_empty() {
+            writeln!(f, "RequiredBy={}", escape_spaces_join(&self.required_by))?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/cli/kube.rs
+++ b/src/cli/kube.rs
@@ -1,6 +1,7 @@
-use std::fmt::Display;
+use std::{convert::Infallible, fmt::Display, path::PathBuf, str::FromStr};
 
 use clap::{Args, Subcommand};
+use url::Url;
 
 use super::container::{user_namespace, Output};
 
@@ -70,7 +71,7 @@ pub struct Play {
     /// The path to the Kubernetes YAML file to use
     ///
     /// Converts to "Yaml=FILE"
-    file: String,
+    file: File,
 }
 
 impl Display for Play {
@@ -98,5 +99,31 @@ impl Display for Play {
         }
 
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum File {
+    Url(Url),
+    Path(PathBuf),
+}
+
+impl FromStr for File {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse() {
+            Ok(url) => Ok(Self::Url(url)),
+            Err(_) => Ok(Self::Path(PathBuf::from(s))),
+        }
+    }
+}
+
+impl Display for File {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            File::Url(url) => write!(f, "{url}"),
+            File::Path(path) => write!(f, "{}", path.display()),
+        }
     }
 }

--- a/src/cli/network.rs
+++ b/src/cli/network.rs
@@ -29,6 +29,13 @@ impl Display for Network {
     }
 }
 
+impl Network {
+    pub fn name(&self) -> &str {
+        let Network::Create { create } = self;
+        &create.name
+    }
+}
+
 #[derive(Args, Debug, Clone, PartialEq)]
 pub struct Create {
     /// Disable the DNS plugin for the network

--- a/src/cli/service.rs
+++ b/src/cli/service.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use clap::{Args, ValueEnum};
 
-#[derive(Args, Debug, Clone, PartialEq, Eq)]
+#[derive(Args, Default, Debug, Clone, PartialEq, Eq)]
 pub struct Service {
     /// Configure if and when the service should be restarted
     #[arg(long, value_name = "POLICY")]
@@ -11,7 +11,7 @@ pub struct Service {
 
 impl Service {
     pub fn is_empty(&self) -> bool {
-        self.restart.is_none()
+        *self == Self::default()
     }
 }
 

--- a/src/cli/unit.rs
+++ b/src/cli/unit.rs
@@ -14,11 +14,47 @@ pub struct Unit {
     /// Converts to "Description=DESCRIPTION"
     #[arg(short, long)]
     description: Option<String>,
+
+    /// Add (weak) requirement dependencies to the unit
+    ///
+    /// Converts to "Wants=WANTS[ ...]"
+    ///
+    /// Can be specified multiple times
+    #[arg(long)]
+    wants: Vec<String>,
+
+    /// Similar to --wants, but adds stronger requirement dependencies
+    ///
+    /// Converts to "Requires=REQUIRES[ ...]"
+    ///
+    /// Can be specified multiple times
+    #[arg(long)]
+    requires: Vec<String>,
+
+    /// Configure ordering dependency between units
+    ///
+    /// Converts to "Before=BEFORE[ ...]"
+    ///
+    /// Can be specified multiple times
+    #[arg(long)]
+    before: Vec<String>,
+
+    /// Configure ordering dependency between units
+    ///
+    /// Converts to "After=AFTER[ ...]"
+    ///
+    /// Can be specified multiple times
+    #[arg(long)]
+    after: Vec<String>,
 }
 
 impl Unit {
     pub fn is_empty(&self) -> bool {
         self.description.is_none()
+            && self.wants.is_empty()
+            && self.requires.is_empty()
+            && self.before.is_empty()
+            && self.after.is_empty()
     }
 }
 
@@ -28,6 +64,22 @@ impl Display for Unit {
 
         if let Some(description) = &self.description {
             writeln!(f, "Description={description}")?;
+        }
+
+        if !self.wants.is_empty() {
+            writeln!(f, "Wants={}", self.wants.join(" "))?;
+        }
+
+        if !self.requires.is_empty() {
+            writeln!(f, "Requires={}", self.requires.join(" "))?;
+        }
+
+        if !self.before.is_empty() {
+            writeln!(f, "Before={}", self.before.join(" "))?;
+        }
+
+        if !self.before.is_empty() {
+            writeln!(f, "After={}", self.after.join(" "))?;
         }
 
         Ok(())

--- a/src/cli/unit.rs
+++ b/src/cli/unit.rs
@@ -5,7 +5,7 @@ use clap::Args;
 /// Common systemd unit options
 ///
 /// From [systemd.unit](https://www.freedesktop.org/software/systemd/man/systemd.unit.html)
-#[derive(Args, Debug, Clone, PartialEq)]
+#[derive(Args, Default, Debug, Clone, PartialEq)]
 pub struct Unit {
     /// Add a description to the unit
     ///
@@ -50,11 +50,7 @@ pub struct Unit {
 
 impl Unit {
     pub fn is_empty(&self) -> bool {
-        self.description.is_none()
-            && self.wants.is_empty()
-            && self.requires.is_empty()
-            && self.before.is_empty()
-            && self.after.is_empty()
+        *self == Self::default()
     }
 }
 

--- a/src/cli/unit.rs
+++ b/src/cli/unit.rs
@@ -1,0 +1,35 @@
+use std::fmt::Display;
+
+use clap::Args;
+
+/// Common systemd unit options
+///
+/// From [systemd.unit](https://www.freedesktop.org/software/systemd/man/systemd.unit.html)
+#[derive(Args, Debug, Clone, PartialEq)]
+pub struct Unit {
+    /// Add a description to the unit
+    ///
+    /// A description should be a short, human readable title of the unit
+    ///
+    /// Converts to "Description=DESCRIPTION"
+    #[arg(short, long)]
+    description: Option<String>,
+}
+
+impl Unit {
+    pub fn is_empty(&self) -> bool {
+        self.description.is_none()
+    }
+}
+
+impl Display for Unit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "[Unit]")?;
+
+        if let Some(description) = &self.description {
+            writeln!(f, "Description={description}")?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/cli/volume.rs
+++ b/src/cli/volume.rs
@@ -31,6 +31,13 @@ impl Display for Volume {
     }
 }
 
+impl Volume {
+    pub fn name(&self) -> &str {
+        let Volume::Create { create } = self;
+        &create.name
+    }
+}
+
 #[derive(Args, Debug, Clone, PartialEq)]
 pub struct Create {
     /// Set driver specific options

--- a/src/cli/volume/opt.rs
+++ b/src/cli/volume/opt.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{convert::Infallible, str::FromStr};
 
 use thiserror::Error;
 
@@ -29,7 +29,7 @@ impl FromStr for Opt {
                 let options = options
                     .split(',')
                     .map(str::parse)
-                    .collect::<Result<Vec<_>, ()>>()
+                    .collect::<Result<Vec<_>, _>>()
                     .expect("Mount::from_str cannot error");
                 Ok(Self::Mount(options))
             }
@@ -52,7 +52,7 @@ pub enum Mount {
 }
 
 impl FromStr for Mount {
-    type Err = ();
+    type Err = Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.starts_with("uid=") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,11 +21,12 @@
 mod cli;
 
 use clap::Parser;
+use color_eyre::eyre;
 
 use self::cli::Cli;
 
-fn main() {
-    let args = Cli::parse();
+fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
 
-    print!("{args}");
+    Cli::parse().print_or_write_file()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,11 +22,10 @@ mod cli;
 
 use clap::Parser;
 
-use self::cli::{Cli, Commands};
+use self::cli::Cli;
 
 fn main() {
     let args = Cli::parse();
 
-    let Commands::Podman { command } = args.command;
-    print!("{command}");
+    print!("{args}");
 }


### PR DESCRIPTION
Adds options to the base `podlet` command for adding common options to the [Unit] and [Install] sections and for writing to a file instead of stdout.