### PR TITLE
Unit directory option flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## [Unreleased]
+## [0.1.1] - 2023-04-19
 
 ### Added
 
 - A container image of podlet now available on [quay.io](https://quay.io/repository/k9withabone/podlet) and [docker hub](https://hub.docker.com/r/k9withabone/podlet).
+- Option flag for outputting to podman unit directory `--unit-directory`.
+    - Places the generated file in the appropriate directory (i.e. `/etc/containers/systemd`, `~/.config/containers/systemd`) for use by quadlet.
 
 ## [0.1.0] - 2023-04-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
+
+[[package]]
 name = "object"
 version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +362,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "ipnet",
+ "nix",
  "shlex",
  "thiserror",
  "url",
@@ -407,6 +420,12 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities"]
 clap = { version = "4.2", features = ["derive"] }
 color-eyre = "0.6"
 ipnet = "2.7"
+nix = { version = "0.26.2", features = ["user"], default-features = false }
 shlex = "1.1"
 thiserror = "1.0.40"
 url = "2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities"]
 clap = { version = "4.2", features = ["derive"] }
 color-eyre = "0.6"
 ipnet = "2.7"
-nix = { version = "0.26.2", features = ["user"], default-features = false }
+nix = { version = "0.26", features = ["user"], default-features = false }
 shlex = "1.1"
 thiserror = "1.0.40"
 url = "2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "podlet"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Paul Nettleton <k9@k9withabone.dev>"]
 edition = "2021"
 description = "Podlet generates podman quadlet (systemd-like) files from a podman command."

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Podlet generates [podman](https://podman.io/) [quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) (systemd-like) files from a podman command.
 
-![Made with VHS](https://vhs.charm.sh/vhs-4x04CoFBi5Hj1EZ0zKlSWE.gif)
+![Made with VHS](https://vhs.charm.sh/vhs-7GpylCk1SkTulSrL7jp6UV.gif)
 
 ## Features
 
@@ -44,6 +44,7 @@ Commands:
 
 Options:
   -f, --file [<FILE>]              Generate a file instead of printing to stdout
+  -u, --unit-directory             Generate a file in the podman unit directory instead of printing to stdout [aliases: unit-dir]
   -n, --name <NAME>                Override the name of the generated file (without the extension)
   -d, --description <DESCRIPTION>  Add a description to the unit
       --wants <WANTS>              Add (weak) requirement dependencies to the unit

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,7 @@ use color_eyre::{
     eyre::{self, Context},
     Help,
 };
+#[cfg(unix)]
 use nix::unistd::Uid;
 
 use self::{
@@ -121,21 +122,7 @@ impl Cli {
     /// Returns the file path for the generated file
     fn file_path(&self) -> eyre::Result<Cow<Path>> {
         let mut path = if self.unit_directory {
-            if Uid::current().is_root() {
-                let path = PathBuf::from("/etc/containers/systemd/");
-                if path.is_dir() {
-                    path
-                } else {
-                    PathBuf::from("/usr/share/containers/systemd/")
-                }
-            } else {
-                let mut path: PathBuf = env::var("XDG_CONFIG_HOME")
-                    .or_else(|_| env::var("HOME").map(|home| format!("{home}/.config")))
-                    .unwrap_or_else(|_| String::from("~/.config/"))
-                    .into();
-                path.push("containers/systemd/");
-                path
-            }
+            unit_dir()
         } else if let Some(Some(path)) = &self.file {
             if path.is_dir() {
                 path.clone()
@@ -154,6 +141,30 @@ impl Cli {
 
         Ok(path.into())
     }
+}
+
+#[cfg(unix)]
+fn unit_dir() -> PathBuf {
+    if Uid::current().is_root() {
+        let path = PathBuf::from("/etc/containers/systemd/");
+        if path.is_dir() {
+            path
+        } else {
+            PathBuf::from("/usr/share/containers/systemd/")
+        }
+    } else {
+        let mut path: PathBuf = env::var("XDG_CONFIG_HOME")
+            .or_else(|_| env::var("HOME").map(|home| format!("{home}/.config")))
+            .unwrap_or_else(|_| String::from("~/.config/"))
+            .into();
+        path.push("containers/systemd/");
+        path
+    }
+}
+
+#[cfg(not(unix))]
+fn unit_dir() -> PathBuf {
+    panic!("Cannot get podman unit directory on non-unix system");
 }
 
 #[derive(Subcommand, Debug, Clone, PartialEq)]


### PR DESCRIPTION
Closes #12, adds an option flag for putting the generated file in the appropriate directory for quadlet. Also prepares for a v0.1.1 release.