### PR TITLE
Fix release container ci

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -4,49 +4,60 @@ name: Release Container
 on:
   push:
     tags:
-      - '*-?v[0-9]+*'
+      - 'v[0-9]+*'
+
+env:
+  MANIFEST: podlet-multiarch
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # From https://podman.io/docs/installation#ubuntu
+      # There is a bug in earlier versions of buildah/podman where the TARGETPLATFORM arg is not set correctly
+      - name: Upgrade podman
+        run: |
+          sudo mkdir -p /etc/apt/keyrings && \
+          curl -fsSL \
+            "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_22.04/Release.key" \
+            | gpg --dearmor \
+            | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null && \
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_22.04/ /" \
+            | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null && \
+          sudo apt update && \
+          sudo apt install -y podman
+
+      - run: podman version
+      
       - name: Build image
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: podlet
-          tags: latest ${{ github.ref_name }}
-          platforms: linux/amd64, linux/arm64/v8
-          layers: true
-          oci: true
-          containerfiles: |
-            ./Containerfile
+        run: |
+          podman build --manifest "${MANIFEST}" \
+            --platform linux/amd64,linux/arm64/v8 -t podlet .
 
       - name: Push to quay.io
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: quay.io/k9withabone
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Print quay.io url
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        env:
+          USERNAME: ${{ secrets.QUAY_USERNAME }}
+          PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+        run: |
+          podman manifest push "${MANIFEST}:latest" \
+            --creds "${USERNAME}:${PASSWORD}" \
+            "docker://quay.io/k9withabone/podlet:${GITHUB_REF_NAME}" && \
+          podman manifest push "${MANIFEST}:latest" \
+            --creds "${USERNAME}:${PASSWORD}" \
+            "docker://quay.io/k9withabone/podlet:latest"
 
       - name: Push to docker.io
-        id: push-to-docker
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: docker.io/k9withabone
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Print docker url
-        run: echo "Image pushed to ${{ steps.push-to-docker.outputs.registry-paths }}"
+        env:
+          USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          podman manifest push "${MANIFEST}:latest" \
+            --creds "${USERNAME}:${PASSWORD}" \
+            "docker://docker.io/k9withabone/podlet:${GITHUB_REF_NAME}" && \
+          podman manifest push "${MANIFEST}:latest" \
+            --creds "${USERNAME}:${PASSWORD}" \
+            "docker://docker.io/k9withabone/podlet:latest"

--- a/Containerfile
+++ b/Containerfile
@@ -1,12 +1,13 @@
 FROM --platform=$BUILDPLATFORM docker.io/library/rust:1 AS chef
 WORKDIR /app
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc
-RUN apt update && apt install -y gcc-aarch64-linux-gnu
-RUN cargo install cargo-chef
+RUN ["/bin/bash", "-c", "set -o pipefail && curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash"]
+RUN cargo binstall -y cargo-chef
 ARG TARGETPLATFORM
 RUN case "$TARGETPLATFORM" in \
   "linux/amd64") echo x86_64-unknown-linux-musl > /rust_target.txt ;; \
-  "linux/arm64/v8") echo aarch64-unknown-linux-musl > /rust_target.txt ;; \
+  "linux/arm64/v8") echo aarch64-unknown-linux-musl > /rust_target.txt && \
+     apt update && apt install -y gcc-aarch64-linux-gnu ;; \
   *) exit 1 ;; \
 esac
 RUN rustup target add $(cat /rust_target.txt)

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -624,7 +624,7 @@ fn volumes_try_into_short(
                     }
                     "bind" => {
                         let Some(source) = source else {
-                            return Some(Err(eyre::eyre!("bind mount without a source")))
+                            return Some(Err(eyre::eyre!("bind mount without a source")));
                         };
                         let read_only = if read_only { ",ro" } else { "" };
                         let propagation = bind


### PR DESCRIPTION
Hopefully fixes CI container releases. Upgrades podman to the latest version as the buildah/podman version in Ubuntu 22.04 has a bug where the TARGETPLATFORM arg is not set correctly. Also changed to using roughly the same commands I used to build and upload the last two versions of the container.

Switched to using cargo-binstall to install cargo-chef in the container and only install `gcc-aarch64-linux-gnu` on arm64 builds.