### PR TITLE
Podman v4.7.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,9 @@ jobs:
 
       - run: podman version
 
+      - id: conmon_version
+        run: echo version="$(conmon --version | head -n 1)" >> $GITHUB_OUTPUT
+
       - name: Build ARM image
         run: podman build --platform linux/arm64/v8 -t podlet .
 
@@ -68,4 +71,7 @@ jobs:
         run: podman build --platform linux/amd64 -t podlet .
 
       - name: Test run image
+        # There is a regression in conmon v2.1.9 which causes this step to fail.
+        # See https://github.com/containers/conmon/issues/475
+        if: ${{ ! contains(steps.conmon_version.outputs.version, '2.1.9') }}
         run: podman run localhost/podlet -h

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can also view the demo on [asciinema](https://asciinema.org/a/591369).
 
 ## Features
 
-- Designed for podman v4.6.0 and newer
+- Designed for podman v4.7.0 and newer
 - Supports the following podman commands:
     - `podman run`
     - `podman kube play`
@@ -148,7 +148,7 @@ Podlet is not (yet) a validator for podman commands. Some podman options are inc
 
 When converting compose files, not all options are supported by podman/quadlet. This is especially true when converting to a pod as some options must be applied to the pod as a whole. If podlet encounters an unsupported option an error will be returned. You will have to remove or comment out unsupported options to proceed.
 
-Podlet is meant to be used with podman v4.6.0 or newer. Some quadlet options are unavailable or behave differently with earlier versions of podman/quadlet.
+Podlet is meant to be used with podman v4.7.0 or newer. Some quadlet options are unavailable or behave differently with earlier versions of podman/quadlet.
 
 ## Contribution
 

--- a/src/cli/container/podman.rs
+++ b/src/cli/container/podman.rs
@@ -183,11 +183,6 @@ pub struct PodmanArgs {
     #[serde(skip_serializing_if = "Not::not")]
     disable_content_trust: bool,
 
-    /// Set custom DNS search domains
-    #[arg(long, value_name = "DOMAIN")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    dns_search: Option<String>,
-
     /// Override the default entrypoint of the image
     #[arg(long, value_name = "\"COMMAND\" | '[\"COMMAND\", \"ARG1\", ...]'")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -550,7 +545,6 @@ impl Default for PodmanArgs {
             device_write_bps: Vec::new(),
             device_write_iops: Vec::new(),
             disable_content_trust: false,
-            dns_search: None,
             entrypoint: None,
             env_merge: Vec::new(),
             gidmap: Vec::new(),

--- a/src/cli/container/podman.rs
+++ b/src/cli/container/podman.rs
@@ -341,11 +341,6 @@ pub struct PodmanArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pidfile: Option<PathBuf>,
 
-    /// Tune the container’s pids limit
-    #[arg(long, value_name = "LIMIT")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pids_limit: Option<i16>,
-
     /// Specify the platform for selecting the image
     #[arg(long, value_name = "OS/ARCH")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -575,7 +570,6 @@ impl Default for PodmanArgs {
             personality: None,
             pid: None,
             pidfile: None,
-            pids_limit: None,
             platform: None,
             pod: None,
             pod_id_file: None,

--- a/src/cli/container/podman.rs
+++ b/src/cli/container/podman.rs
@@ -183,11 +183,6 @@ pub struct PodmanArgs {
     #[serde(skip_serializing_if = "Not::not")]
     disable_content_trust: bool,
 
-    /// Set custom DNS options
-    #[arg(long, value_name = "OPTION")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    dns_option: Option<String>,
-
     /// Set custom DNS search domains
     #[arg(long, value_name = "DOMAIN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -555,7 +550,6 @@ impl Default for PodmanArgs {
             device_write_bps: Vec::new(),
             device_write_iops: Vec::new(),
             disable_content_trust: false,
-            dns_option: None,
             dns_search: None,
             entrypoint: None,
             env_merge: Vec::new(),

--- a/src/cli/container/podman.rs
+++ b/src/cli/container/podman.rs
@@ -410,11 +410,6 @@ pub struct PodmanArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     seccomp_policy: Option<String>,
 
-    /// Size of /dev/shm
-    #[arg(long, value_name = "NUMBER[UNIT]")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    shm_size: Option<String>,
-
     /// Size of systemd-specific tmpfs mounts: /run, /run/lock, /var/log/journal, and /tmp
     #[arg(long, value_name = "NUMBER[UNIT]")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -583,7 +578,6 @@ impl Default for PodmanArgs {
             rm: false,
             rmi: false,
             seccomp_policy: None,
-            shm_size: None,
             shm_size_systemd: None,
             sig_proxy: true,
             stop_signal: None,
@@ -675,7 +669,6 @@ impl TryFrom<&mut docker_compose_types::Service> for PodmanArgs {
             stop_timeout,
             ipc: value.ipc.take(),
             interactive: value.stdin_open,
-            shm_size: value.shm_size.take(),
             log_opt,
             add_host: mem::take(&mut value.extra_hosts),
             tty: value.tty,

--- a/src/cli/container/podman.rs
+++ b/src/cli/container/podman.rs
@@ -183,11 +183,6 @@ pub struct PodmanArgs {
     #[serde(skip_serializing_if = "Not::not")]
     disable_content_trust: bool,
 
-    /// Set custom DNS servers
-    #[arg(long, value_name = "IP_ADDRESS")]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    dns: Vec<String>,
-
     /// Set custom DNS options
     #[arg(long, value_name = "OPTION")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -560,7 +555,6 @@ impl Default for PodmanArgs {
             device_write_bps: Vec::new(),
             device_write_iops: Vec::new(),
             disable_content_trust: false,
-            dns: Vec::new(),
             dns_option: None,
             dns_search: None,
             entrypoint: None,
@@ -697,7 +691,6 @@ impl TryFrom<&mut docker_compose_types::Service> for PodmanArgs {
             group_add: mem::take(&mut value.group_add),
             stop_signal: value.stop_signal.take(),
             stop_timeout,
-            dns: mem::take(&mut value.dns),
             ipc: value.ipc.take(),
             interactive: value.stdin_open,
             shm_size: value.shm_size.take(),

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -54,6 +54,12 @@ pub struct QuadletOptions {
     #[arg(long, value_name = "IP_ADDRESS")]
     dns: Vec<String>,
 
+    /// Set custom DNS options
+    ///
+    /// Converts to "DNSOption=OPTION"
+    #[arg(long, value_name = "OPTION")]
+    dns_option: Vec<String>,
+
     /// Drop Linux capability from the default podman capability set
     ///
     /// If unspecified, the default is `all`
@@ -365,6 +371,7 @@ impl From<QuadletOptions> for crate::quadlet::Container {
             auto_update,
             container_name: value.name,
             dns: value.dns,
+            dns_option: value.dns_option,
             drop_capability: value.cap_drop,
             environment: value.env,
             environment_file: value.env_file,

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -232,6 +232,12 @@ pub struct QuadletOptions {
     #[arg(long, value_enum, default_value_t)]
     sdnotify: Notify,
 
+    /// Tune the container’s pids limit
+    ///
+    /// Converts to "PidsLimit=LIMIT"
+    #[arg(long, value_name = "LIMIT")]
+    pids_limit: Option<i16>,
+
     /// The rootfs to use for the container
     ///
     /// Converts to "Rootfs=PATH"
@@ -411,6 +417,7 @@ impl From<QuadletOptions> for crate::quadlet::Container {
             network: value.network,
             rootfs: value.rootfs,
             notify: value.sdnotify.is_container(),
+            pids_limit: value.pids_limit,
             publish_port: value.publish,
             pull: value.pull,
             read_only: value.read_only,

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -51,14 +51,26 @@ pub struct QuadletOptions {
     /// Set custom DNS servers
     ///
     /// Converts to "DNS=IP_ADDRESS"
+    ///
+    /// Can be specified multiple times
     #[arg(long, value_name = "IP_ADDRESS")]
     dns: Vec<String>,
 
     /// Set custom DNS options
     ///
     /// Converts to "DNSOption=OPTION"
+    ///
+    /// Can be specified multiple times
     #[arg(long, value_name = "OPTION")]
     dns_option: Vec<String>,
+
+    /// Set custom DNS search domains
+    ///
+    /// Converts to "DNSSearch=DOMAIN"
+    ///
+    /// Can be specified multiple times
+    #[arg(long, value_name = "DOMAIN")]
+    dns_search: Vec<String>,
 
     /// Drop Linux capability from the default podman capability set
     ///
@@ -372,6 +384,7 @@ impl From<QuadletOptions> for crate::quadlet::Container {
             container_name: value.name,
             dns: value.dns,
             dns_option: value.dns_option,
+            dns_search: value.dns_search,
             drop_capability: value.cap_drop,
             environment: value.env,
             environment_file: value.env_file,

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -282,6 +282,12 @@ pub struct QuadletOptions {
     #[arg(long, value_name = "SECRET[,OPT=OPT,...]")]
     secret: Vec<String>,
 
+    /// Size of /dev/shm
+    ///
+    /// Converts to "ShmSize=NUMBER[UNIT]"
+    #[arg(long, value_name = "NUMBER[UNIT]")]
+    shm_size: Option<String>,
+
     /// Configures namespaced kernel parameters for the container.
     ///
     /// Converts to "Sysctl=NAME=VALUE"
@@ -423,6 +429,7 @@ impl From<QuadletOptions> for crate::quadlet::Container {
             read_only: value.read_only,
             run_init: value.init,
             secret: value.secret,
+            shm_size: value.shm_size,
             sysctl: value.sysctl,
             tmpfs,
             timezone: value.tz,
@@ -556,6 +563,7 @@ impl TryFrom<&mut ComposeService> for QuadletOptions {
             health_start_period,
             health_timeout,
             hostname: service.hostname.take(),
+            shm_size: service.shm_size.take(),
             sysctl,
             tmpfs,
             mount,

--- a/src/cli/container/quadlet.rs
+++ b/src/cli/container/quadlet.rs
@@ -48,6 +48,12 @@ pub struct QuadletOptions {
     #[arg(long)]
     pub name: Option<String>,
 
+    /// Set custom DNS servers
+    ///
+    /// Converts to "DNS=IP_ADDRESS"
+    #[arg(long, value_name = "IP_ADDRESS")]
+    dns: Vec<String>,
+
     /// Drop Linux capability from the default podman capability set
     ///
     /// If unspecified, the default is `all`
@@ -358,6 +364,7 @@ impl From<QuadletOptions> for crate::quadlet::Container {
             annotation: value.annotation,
             auto_update,
             container_name: value.name,
+            dns: value.dns,
             drop_capability: value.cap_drop,
             environment: value.env,
             environment_file: value.env_file,
@@ -508,6 +515,7 @@ impl TryFrom<&mut ComposeService> for QuadletOptions {
         Ok(Self {
             cap_add: mem::take(&mut service.cap_add),
             name: service.container_name.take(),
+            dns: mem::take(&mut service.dns),
             cap_drop: mem::take(&mut service.cap_drop),
             publish,
             env,

--- a/src/cli/kube.rs
+++ b/src/cli/kube.rs
@@ -12,6 +12,8 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 use url::Url;
 
+use crate::quadlet::KubeAutoUpdate;
+
 #[derive(Subcommand, Debug, Clone, PartialEq)]
 pub enum Kube {
     /// Generate a podman quadlet `.kube` file
@@ -98,9 +100,12 @@ pub struct Play {
 }
 
 impl From<Play> for crate::quadlet::Kube {
-    fn from(value: Play) -> Self {
+    fn from(mut value: Play) -> Self {
+        let auto_update =
+            KubeAutoUpdate::extract_from_annotations(&mut value.podman_args.annotation);
         let podman_args = value.podman_args.to_string();
         Self {
+            auto_update,
             config_map: value.configmap,
             log_driver: value.log_driver,
             network: value.network,

--- a/src/cli/network.rs
+++ b/src/cli/network.rs
@@ -51,6 +51,14 @@ pub struct Create {
     #[arg(long)]
     disable_dns: bool,
 
+    /// Set network-scoped DNS resolver/nameserver for containers in this network
+    ///
+    /// Converts to "DNS=IP"
+    ///
+    /// Can be specified multiple times
+    #[arg(long, value_name = "IP")]
+    dns: Vec<String>,
+
     /// Driver to manage the network
     ///
     /// Converts to "Driver=DRIVER"
@@ -131,6 +139,7 @@ impl From<Create> for crate::quadlet::Network {
         let podman_args = value.podman_args.to_string();
         Self {
             disable_dns: value.disable_dns,
+            dns: value.dns,
             driver: value.driver,
             gateway: value.gateway,
             internal: value.internal,
@@ -148,13 +157,6 @@ impl From<Create> for crate::quadlet::Network {
 #[derive(Args, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 struct PodmanArgs {
-    /// Set network-scoped DNS resolver/nameserver for containers in this network
-    ///
-    /// Can be specified multiple times
-    #[arg(long, value_name = "IP")]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    dns: Vec<String>,
-
     /// Maps to the `network_interface` option in the network config
     #[arg(long, value_name = "NAME")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/quadlet.rs
+++ b/src/quadlet.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 pub use self::{
     container::{Container, PullPolicy, Unmask},
     install::Install,
-    kube::Kube,
+    kube::{AutoUpdate as KubeAutoUpdate, Kube},
     network::Network,
     volume::Volume,
 };

--- a/src/quadlet/container.rs
+++ b/src/quadlet/container.rs
@@ -226,6 +226,9 @@ pub struct Container {
     /// The timezone to run the container in.
     pub timezone: Option<String>,
 
+    /// Ulimit options. Sets the ulimits values inside of the container.
+    pub ulimit: Vec<String>,
+
     /// The paths to unmask.
     pub unmask: Option<Unmask>,
 

--- a/src/quadlet/container.rs
+++ b/src/quadlet/container.rs
@@ -210,6 +210,9 @@ pub struct Container {
     /// Use a Podman secret in the container either as a file or an environment variable.
     pub secret: Vec<String>,
 
+    /// Size of `/dev/shm`.
+    pub shm_size: Option<String>,
+
     /// Configures namespaced kernel parameters for the container.
     #[serde(
         serialize_with = "quote_spaces_join_space",

--- a/src/quadlet/container.rs
+++ b/src/quadlet/container.rs
@@ -44,6 +44,10 @@ pub struct Container {
     #[serde(rename = "DNS")]
     pub dns: Vec<String>,
 
+    /// Set custom DNS options.
+    #[serde(rename = "DNSOption")]
+    pub dns_option: Vec<String>,
+
     /// Drop these capabilities from the default podman capability set, or `all` to drop all capabilities.
     #[serde(
         serialize_with = "quote_spaces_join_space",

--- a/src/quadlet/container.rs
+++ b/src/quadlet/container.rs
@@ -165,6 +165,9 @@ pub struct Container {
     #[serde(skip_serializing_if = "Not::not")]
     pub notify: bool,
 
+    /// Tune the container’s pids limit.
+    pub pids_limit: Option<i16>,
+
     /// A list of arguments passed directly to the end of the `podman run` command
     /// in the generated file, right before the image name in the command line.
     pub podman_args: Option<String>,

--- a/src/quadlet/container.rs
+++ b/src/quadlet/container.rs
@@ -40,6 +40,10 @@ pub struct Container {
     /// The (optional) name of the Podman container.
     pub container_name: Option<String>,
 
+    /// Set network-scoped DNS resolver/nameserver for containers in this network.
+    #[serde(rename = "DNS")]
+    pub dns: Vec<String>,
+
     /// Drop these capabilities from the default podman capability set, or `all` to drop all capabilities.
     #[serde(
         serialize_with = "quote_spaces_join_space",

--- a/src/quadlet/container.rs
+++ b/src/quadlet/container.rs
@@ -48,6 +48,10 @@ pub struct Container {
     #[serde(rename = "DNSOption")]
     pub dns_option: Vec<String>,
 
+    /// Set custom DNS search domains.
+    #[serde(rename = "DNSSearch")]
+    pub dns_search: Vec<String>,
+
     /// Drop these capabilities from the default podman capability set, or `all` to drop all capabilities.
     #[serde(
         serialize_with = "quote_spaces_join_space",

--- a/src/quadlet/kube.rs
+++ b/src/quadlet/kube.rs
@@ -3,11 +3,14 @@ use std::{
     path::PathBuf,
 };
 
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 #[derive(Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Kube {
+    /// Indicates whether containers will be auto-updated.
+    pub auto_update: Vec<AutoUpdate>,
+
     /// Pass the Kubernetes ConfigMap YAML at path to `podman kube play`.
     pub config_map: Vec<PathBuf>,
 
@@ -36,6 +39,7 @@ pub struct Kube {
 impl Kube {
     pub fn new(yaml: String) -> Self {
         Self {
+            auto_update: Vec::new(),
             config_map: Vec::new(),
             log_driver: None,
             network: Vec::new(),
@@ -54,6 +58,64 @@ impl Display for Kube {
     }
 }
 
+/// Valid values for the `AutoUpdate=` kube quadlet option.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AutoUpdate {
+    All(super::AutoUpdate),
+    Container {
+        container: String,
+        auto_update: super::AutoUpdate,
+    },
+}
+
+impl AutoUpdate {
+    /// Extracts all valid values of the `io.containers.autoupdate` annotation from `annotations`,
+    /// the last value of which is parsed into an [`AutoUpdate`].
+    ///
+    /// Returns an empty `Vec` if no valid `io.containers.autoupdate` annotation is found.
+    ///
+    /// `io.containers.autoupdate` annotations with invalid values are retained in `annotations`.
+    pub fn extract_from_annotations(annotations: &mut Vec<String>) -> Vec<Self> {
+        let mut auto_updates = Vec::new();
+        annotations.retain(|annotation| {
+            // auto-update annotations are in the form `io.containers.autoupdate=[registry|local]`
+            // or `io.containers.autoupdate/$container=[registry|local]`
+            // see https://docs.podman.io/en/stable/markdown/podman-auto-update.1.html#auto-updates-and-kubernetes-yaml
+            annotation
+                .strip_prefix("io.containers.autoupdate")
+                .and_then(|auto_update| {
+                    let (container, auto_update) = auto_update.split_once('=')?;
+                    let auto_update = auto_update.parse().ok()?;
+                    container
+                        .strip_prefix('/')
+                        .map(|container| Self::Container {
+                            container: container.to_owned(),
+                            auto_update,
+                        })
+                        .or_else(|| container.is_empty().then_some(Self::All(auto_update)))
+                })
+                .map_or(true, |auto_update| {
+                    auto_updates.push(auto_update);
+                    false
+                })
+        });
+
+        auto_updates
+    }
+}
+
+impl Serialize for AutoUpdate {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::All(auto_update) => auto_update.serialize(serializer),
+            Self::Container {
+                container,
+                auto_update,
+            } => format!("{container}/{auto_update}").serialize(serializer),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -62,5 +124,37 @@ mod tests {
     fn kube_default_empty() {
         let kube = Kube::new(String::from("yaml"));
         assert_eq!(kube.to_string(), "[Kube]\nYaml=yaml\n");
+    }
+
+    #[test]
+    fn auto_update_extract() {
+        let mut annotations = vec![
+            String::from("annotation"),
+            String::from("io.containers.autoupdate=invalid"),
+            String::from("io.containers.autoupdate#invalid=registry"),
+            String::from("io.containers.autoupdate=registry"),
+            String::from("io.containers.autoupdate/container=local"),
+        ];
+
+        let auto_updates = AutoUpdate::extract_from_annotations(&mut annotations);
+
+        assert_eq!(
+            auto_updates,
+            [
+                AutoUpdate::All(crate::quadlet::AutoUpdate::Registry),
+                AutoUpdate::Container {
+                    container: String::from("container"),
+                    auto_update: crate::quadlet::AutoUpdate::Local
+                }
+            ]
+        );
+        assert_eq!(
+            annotations,
+            [
+                "annotation",
+                "io.containers.autoupdate=invalid",
+                "io.containers.autoupdate#invalid=registry"
+            ]
+        );
     }
 }

--- a/src/quadlet/network.rs
+++ b/src/quadlet/network.rs
@@ -14,8 +14,12 @@ use crate::serde::quadlet::quote_spaces_join_space;
 #[serde(rename_all = "PascalCase")]
 pub struct Network {
     /// If enabled, disables the DNS plugin for this network.
-    #[serde(skip_serializing_if = "Not::not")]
+    #[serde(rename = "DisableDNS", skip_serializing_if = "Not::not")]
     pub disable_dns: bool,
+
+    /// Set network-scoped DNS resolver/nameserver for containers in this network.
+    #[serde(rename = "DNS")]
+    pub dns: Vec<String>,
 
     /// Driver to manage the network.
     pub driver: Option<String>,


### PR DESCRIPTION
Closes #29.

Adds support for quadlet options introduced in podman v4.7.0, bumping the minimum supported podman version.