### PR TITLE
Generate quadlet from an existing container, network, or volume

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -265,7 +265,7 @@ enum Commands {
         compose_file: Option<PathBuf>,
     },
 
-    /// Generate a podman quadlet file from an existing container.
+    /// Generate a podman quadlet file from an existing container or network.
     ///
     /// Note: these commands require that podman is installed and is searchable
     /// from the `PATH` environment variable.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -265,7 +265,7 @@ enum Commands {
         compose_file: Option<PathBuf>,
     },
 
-    /// Generate a podman quadlet file from an existing container or network.
+    /// Generate a podman quadlet file from an existing container, network, or volume.
     ///
     /// Note: these commands require that podman is installed and is searchable
     /// from the `PATH` environment variable.

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -1,0 +1,170 @@
+//! Provides the `podlet generate` subcommand, see [`Generate`].
+//!
+//! `podlet generate` uses the podman `inspect` commands to get information on the selected
+//! resource. The information is converted into a [`PodmanCommands`] which, in turn, is turned into
+//! a [`crate::quadlet::File`].
+
+use std::process::Command;
+
+use clap::{Parser, Subcommand};
+use color_eyre::{
+    eyre::{eyre, WrapErr},
+    Section, SectionExt,
+};
+use serde::Deserialize;
+
+use super::{container::Container, service::Service, PodmanCommands};
+
+/// [`Subcommand`] for `podlet generate`
+#[derive(Subcommand, Debug, Clone, PartialEq)]
+pub enum Generate {
+    /// Generate a quadlet file from an existing container
+    ///
+    /// The command used to create the container is parsed to generate the quadlet file.
+    Container {
+        /// Name of the container
+        container: String,
+    },
+}
+
+impl TryFrom<Generate> for PodmanCommands {
+    type Error = color_eyre::Report;
+
+    fn try_from(value: Generate) -> Result<Self, Self::Error> {
+        match value {
+            Generate::Container { container } => {
+                ContainerParser::from_container(&container).map(Into::into)
+            }
+        }
+    }
+}
+
+/// [`Parser`] for container creation CLI options.
+#[derive(Parser, Debug)]
+#[command(no_binary_name = true)]
+struct ContainerParser {
+    /// The \[Container\] section
+    #[command(flatten)]
+    container: Container,
+    /// The \[Service\] section
+    #[command(flatten)]
+    service: Service,
+}
+
+impl ContainerParser {
+    /// Runs `podman container inspect` on the container and parses the create command.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if there is an error getting the create command,
+    /// or if it cannot be successfully parsed into container creation CLI options.
+    fn from_container(container: &str) -> color_eyre::Result<Self> {
+        let create_command = ContainerInspect::from_container(container)
+            .wrap_err_with(|| {
+                format!("error getting command used to create container: {container}")
+            })?
+            .config
+            .create_command;
+
+        Self::try_parse_from(strip_container_create_command_prefix(&create_command)).wrap_err_with(
+            || {
+                format!(
+                    "error parsing podman command from: {}",
+                    shlex::join(create_command.iter().map(String::as_str))
+                )
+            },
+        )
+    }
+}
+
+/// Remove the command part of `command`, leaving just the container creation options.
+fn strip_container_create_command_prefix(command: &[String]) -> impl Iterator<Item = &String> {
+    let mut iter = command.iter().peekable();
+
+    // remove arg0, i.e. "podman" or "/usr/bin/podman"
+    iter.next();
+
+    // command could be `podman run`, `podman create`, or `podman container create`
+    if iter.peek().is_some_and(|arg| *arg == "container") {
+        iter.next();
+    }
+    if iter
+        .peek()
+        .is_some_and(|arg| *arg == "run" || *arg == "create")
+    {
+        iter.next();
+    }
+
+    iter
+}
+
+impl From<ContainerParser> for PodmanCommands {
+    fn from(ContainerParser { container, service }: ContainerParser) -> Self {
+        PodmanCommands::Run {
+            container: Box::new(container),
+            service,
+        }
+    }
+}
+
+/// Selected output of `podman container inspect`.
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct ContainerInspect {
+    config: ContainerConfig,
+}
+
+/// Part of `Config` object from the output of `podman container inspect`
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct ContainerConfig {
+    create_command: Vec<String>,
+}
+
+impl ContainerInspect {
+    /// Runs `podman container inspect` on the container and deserializes the output into [`Self`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if there is problem running `podman container inspect`,
+    /// it doesn't complete successfully,
+    /// or if the output cannot be properly deserialized.
+    fn from_container(container: &str) -> color_eyre::Result<Self> {
+        let output = Command::new("podman")
+            .args(["container", "inspect", container])
+            .output()
+            .wrap_err_with(|| format!("error running `podman container inspect {container}`"))
+            .note("ensure podman is installed and available on $PATH")?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return if let Some(code) = output.status.code() {
+                Err(eyre!(
+                    "`podman container inspect {container}` \
+                        exited unsuccessfully with status code: {code}"
+                ))
+            } else {
+                Err(eyre!(
+                    "`podman container inspect {container}` \
+                        was terminated by a signal"
+                ))
+            }
+            .section(stdout.trim().to_owned().header("Podman Stdout:"))
+            .section(stderr.trim().to_owned().header("Podman Stderr:"));
+        }
+
+        // `podman container inspect` returns a JSON array which is also valid YAML so serde_yaml can
+        // be reused. There should only be a single object in the array, so the first one is returned.
+        serde_yaml::from_str::<Vec<Self>>(&stdout)
+            .wrap_err(
+                "error deserializing container create command \
+                        from `podman container inspect` output",
+            )
+            .with_section(|| stdout.trim().to_owned().header("Podman Stdout:"))?
+            .into_iter()
+            .next()
+            .ok_or_else(|| eyre!("no containers matching `{container}`"))
+    }
+}

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -4,16 +4,29 @@
 //! resource. The information is converted into a [`PodmanCommands`] which, in turn, is turned into
 //! a [`crate::quadlet::File`].
 
-use std::process::Command;
+use std::{
+    fmt::{self, Display, Formatter},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    process::Command,
+};
 
 use clap::{Parser, Subcommand};
 use color_eyre::{
     eyre::{eyre, WrapErr},
     Section, SectionExt,
 };
-use serde::Deserialize;
+use indexmap::IndexMap;
+use ipnet::IpNet;
+use serde::{de::DeserializeOwned, Deserialize};
 
-use super::{container::Container, service::Service, PodmanCommands};
+use crate::quadlet::IpRange;
+
+use super::{
+    container::Container,
+    network::{self, Network},
+    service::Service,
+    PodmanCommands,
+};
 
 /// [`Subcommand`] for `podlet generate`
 #[derive(Subcommand, Debug, Clone, PartialEq)]
@@ -25,6 +38,19 @@ pub enum Generate {
         /// Name of the container
         container: String,
     },
+
+    /// Generate a quadlet file from an existing network
+    ///
+    /// The generated quadlet file will be larger than strictly necessary.
+    /// It is impossible to determine which CLI options were explicitly set when the network was
+    /// created from the output of `podman network inspect`.
+    ///
+    /// You may wish to remove some of the generated quadlet options for which you do not need a
+    /// precise value.
+    Network {
+        /// Name of the network
+        network: String,
+    },
 }
 
 impl TryFrom<Generate> for PodmanCommands {
@@ -35,6 +61,9 @@ impl TryFrom<Generate> for PodmanCommands {
             Generate::Container { container } => {
                 ContainerParser::from_container(&container).map(Into::into)
             }
+            Generate::Network { network } => Ok(Self::Network {
+                network: Box::new(NetworkInspect::from_network(&network)?.into()),
+            }),
         }
     }
 }
@@ -130,41 +159,272 @@ impl ContainerInspect {
     /// it doesn't complete successfully,
     /// or if the output cannot be properly deserialized.
     fn from_container(container: &str) -> color_eyre::Result<Self> {
-        let output = Command::new("podman")
-            .args(["container", "inspect", container])
-            .output()
-            .wrap_err_with(|| format!("error running `podman container inspect {container}`"))
-            .note("ensure podman is installed and available on $PATH")?;
+        podman_inspect(ResourceKind::Container, container)
+    }
+}
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
+/// Output of `podman network inspect`.
+#[derive(Deserialize, Debug)]
+struct NetworkInspect {
+    /// name
+    name: String,
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return if let Some(code) = output.status.code() {
-                Err(eyre!(
-                    "`podman container inspect {container}` \
-                        exited unsuccessfully with status code: {code}"
-                ))
-            } else {
-                Err(eyre!(
-                    "`podman container inspect {container}` \
-                        was terminated by a signal"
-                ))
-            }
-            .section(stdout.trim().to_owned().header("Podman Stdout:"))
-            .section(stderr.trim().to_owned().header("Podman Stderr:"));
+    /// --driver
+    driver: String,
+
+    /// --interface-name
+    network_interface: String,
+
+    /// --subnet, --gateway, --ip-range
+    #[serde(default)]
+    subnets: Vec<NetworkSubnet>,
+
+    /// --route
+    #[serde(default)]
+    routes: Vec<NetworkRoute>,
+
+    /// --ipv6
+    ipv6_enabled: bool,
+
+    /// --internal
+    internal: bool,
+
+    /// ! --disable-dns
+    dns_enabled: bool,
+
+    /// --dns
+    #[serde(default)]
+    network_dns_servers: Vec<IpAddr>,
+
+    /// --label
+    #[serde(default)]
+    labels: IndexMap<String, String>,
+
+    /// --opt
+    #[serde(default)]
+    options: IndexMap<String, String>,
+
+    /// --ipam-driver
+    ipam_options: NetworkIpamOptions,
+}
+
+#[derive(Deserialize, Debug)]
+struct NetworkSubnet {
+    /// --subnet
+    subnet: IpNet,
+
+    /// --gateway
+    #[serde(default)]
+    gateway: Option<IpAddr>,
+
+    /// --ip-range
+    #[serde(default)]
+    lease_range: Option<NetworkLeaseRange>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+enum NetworkLeaseRange {
+    Ipv4 {
+        start_ip: Ipv4Addr,
+        end_ip: Ipv4Addr,
+    },
+    Ipv6 {
+        start_ip: Ipv6Addr,
+        end_ip: Ipv6Addr,
+    },
+}
+
+impl From<NetworkLeaseRange> for IpRange {
+    fn from(value: NetworkLeaseRange) -> Self {
+        match value {
+            NetworkLeaseRange::Ipv4 { start_ip, end_ip } => Self::Ipv4Range(start_ip..end_ip),
+            NetworkLeaseRange::Ipv6 { start_ip, end_ip } => Self::Ipv6Range(start_ip..end_ip),
         }
+    }
+}
 
-        // `podman container inspect` returns a JSON array which is also valid YAML so serde_yaml can
-        // be reused. There should only be a single object in the array, so the first one is returned.
-        serde_yaml::from_str::<Vec<Self>>(&stdout)
-            .wrap_err(
+#[derive(Deserialize, Debug)]
+struct NetworkRoute {
+    destination: IpNet,
+    gateway: IpAddr,
+    #[serde(default)]
+    metric: Option<u32>,
+}
+
+impl NetworkRoute {
+    /// Format as value suitable for `podman network create --route`:
+    /// "<destination in CIDR notation>,<gateway>,<route metric (optional)>".
+    fn to_route_value(&self) -> String {
+        let Self {
+            destination,
+            gateway,
+            metric,
+        } = self;
+
+        if let Some(metric) = metric {
+            format!("{destination},{gateway},{metric}")
+        } else {
+            format!("{destination},{gateway}")
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+struct NetworkIpamOptions {
+    /// --ipam-driver
+    driver: String,
+}
+
+impl NetworkInspect {
+    /// Runs `podman network inspect` on the network and deserializes the output into [`Self`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if there is problem running `podman network inspect`,
+    /// it doesn't complete successfully,
+    /// or if the output cannot be properly deserialized.
+    fn from_network(network: &str) -> color_eyre::Result<Self> {
+        podman_inspect(ResourceKind::Network, network)
+    }
+}
+
+impl From<NetworkInspect> for Network {
+    fn from(
+        NetworkInspect {
+            name,
+            driver,
+            network_interface,
+            subnets,
+            routes,
+            ipv6_enabled: ipv6,
+            internal,
+            dns_enabled,
+            network_dns_servers,
+            labels,
+            options,
+            ipam_options: NetworkIpamOptions {
+                driver: ipam_driver,
+            },
+        }: NetworkInspect,
+    ) -> Self {
+        let subnets_len = subnets.len();
+        let (subnet, gateway, ip_range) = subnets.into_iter().fold(
+            (Vec::with_capacity(subnets_len), Vec::new(), Vec::new()),
+            |(mut subnets, mut gateways, mut ip_ranges),
+             NetworkSubnet {
+                 subnet,
+                 gateway,
+                 lease_range,
+             }| {
+                subnets.push(subnet);
+                gateways.extend(gateway);
+                ip_ranges.extend(lease_range.map(Into::into));
+                (subnets, gateways, ip_ranges)
+            },
+        );
+
+        Network::Create {
+            create: network::Create {
+                disable_dns: !dns_enabled,
+                dns: network_dns_servers
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+                driver: Some(driver),
+                gateway,
+                internal,
+                ipam_driver: Some(ipam_driver),
+                ip_range,
+                ipv6,
+                label: labels
+                    .into_iter()
+                    .map(|(label, value)| format!("{label}={value}"))
+                    .collect(),
+                opt: options
+                    .into_iter()
+                    .map(|(opt, value)| format!("{opt}={value}"))
+                    .collect(),
+                subnet,
+                podman_args: network::PodmanArgs {
+                    interface_name: Some(network_interface),
+                    route: routes.iter().map(NetworkRoute::to_route_value).collect(),
+                },
+                name,
+            },
+        }
+    }
+}
+
+/// Runs `podman {resource_kind} inspect` on the resource and deserializes the output.
+///
+/// # Errors
+///
+/// Returns an error if there is problem running `podman {resource_kind} inspect`,
+/// it doesn't complete successfully,
+/// or if the output cannot be properly deserialized.
+fn podman_inspect<T: DeserializeOwned>(
+    resource_kind: ResourceKind,
+    resource: &str,
+) -> color_eyre::Result<T> {
+    let output = Command::new("podman")
+        .args([resource_kind.as_str(), "inspect", resource])
+        .output()
+        .wrap_err_with(|| format!("error running `podman {resource_kind} inspect {resource}`"))
+        .note("ensure podman is installed and available on $PATH")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return if let Some(code) = output.status.code() {
+            Err(eyre!(
+                "`podman {resource_kind} inspect {resource}` \
+                    exited unsuccessfully with status code: {code}"
+            ))
+        } else {
+            Err(eyre!(
+                "`podman {resource_kind} inspect {resource}` \
+                    was terminated by a signal"
+            ))
+        }
+        .section(stdout.trim().to_owned().header("Podman Stdout:"))
+        .section(stderr.trim().to_owned().header("Podman Stderr:"));
+    }
+
+    // `podman inspect` returns a JSON array which is also valid YAML so serde_yaml can be reused.
+    // There should only be a single object in the array, so the first one is returned.
+    serde_yaml::from_str::<Vec<T>>(&stdout)
+        .wrap_err_with(|| {
+            format!(
                 "error deserializing container create command \
-                        from `podman container inspect` output",
+                    from `podman {resource_kind} inspect {resource}` output"
             )
-            .with_section(|| stdout.trim().to_owned().header("Podman Stdout:"))?
-            .into_iter()
-            .next()
-            .ok_or_else(|| eyre!("no containers matching `{container}`"))
+        })
+        .with_section(|| stdout.trim().to_owned().header("Podman Stdout:"))?
+        .into_iter()
+        .next()
+        .ok_or_else(|| eyre!("no {resource_kind}s matching `{resource}`"))
+}
+
+/// Used by [`podman_inspect()`] to run the correct variant of `podman inspect`.
+#[derive(Debug, Clone, Copy)]
+enum ResourceKind {
+    Container,
+    Network,
+}
+
+impl ResourceKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            ResourceKind::Container => "container",
+            ResourceKind::Network => "network",
+        }
+    }
+}
+
+impl Display for ResourceKind {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str(self.as_str())
     }
 }

--- a/src/cli/network.rs
+++ b/src/cli/network.rs
@@ -7,6 +7,8 @@ use clap::{Args, Subcommand};
 use ipnet::IpNet;
 use serde::Serialize;
 
+use crate::quadlet::IpRange;
+
 #[derive(Subcommand, Debug, Clone, PartialEq)]
 pub enum Network {
     /// Generate a podman quadlet `.network` file
@@ -87,11 +89,12 @@ pub struct Create {
 
     /// Allocate container IP from a range
     ///
-    /// The range must be a complete subnet and in CIDR notation
+    /// The range must be a complete subnet in CIDR notation, or be in the `<startIP>-<endIP>`
+    /// syntax which allows for a more flexible range compared to the CIDR subnet.
     ///
     /// Converts to "IPRange=IP_RANGE"
     #[arg(long)]
-    ip_range: Vec<IpNet>,
+    ip_range: Vec<IpRange>,
 
     /// Enable IPv6 (Dual Stack) networking
     ///

--- a/src/cli/network.rs
+++ b/src/cli/network.rs
@@ -51,7 +51,7 @@ pub struct Create {
     ///
     /// Converts to "DisableDNS=true"
     #[arg(long)]
-    disable_dns: bool,
+    pub disable_dns: bool,
 
     /// Set network-scoped DNS resolver/nameserver for containers in this network
     ///
@@ -59,13 +59,13 @@ pub struct Create {
     ///
     /// Can be specified multiple times
     #[arg(long, value_name = "IP")]
-    dns: Vec<String>,
+    pub dns: Vec<String>,
 
     /// Driver to manage the network
     ///
     /// Converts to "Driver=DRIVER"
     #[arg(short, long)]
-    driver: Option<String>,
+    pub driver: Option<String>,
 
     /// Define a gateway for the subnet
     ///
@@ -73,19 +73,19 @@ pub struct Create {
     ///
     /// Can be specified multiple times
     #[arg(long)]
-    gateway: Vec<IpAddr>,
+    pub gateway: Vec<IpAddr>,
 
     /// Restrict external access of the network
     ///
     /// Converts to "Internal=true"
     #[arg(long)]
-    internal: bool,
+    pub internal: bool,
 
     /// Set the IPAM driver (IP Address Management Driver) for the network
     ///
     /// Converts to "IPAMDriver=DRIVER"
     #[arg(long, value_name = "DRIVER")]
-    ipam_driver: Option<String>,
+    pub ipam_driver: Option<String>,
 
     /// Allocate container IP from a range
     ///
@@ -94,13 +94,13 @@ pub struct Create {
     ///
     /// Converts to "IPRange=IP_RANGE"
     #[arg(long)]
-    ip_range: Vec<IpRange>,
+    pub ip_range: Vec<IpRange>,
 
     /// Enable IPv6 (Dual Stack) networking
     ///
     /// Converts to "IPv6=true"
     #[arg(long)]
-    ipv6: bool,
+    pub ipv6: bool,
 
     /// Set one or more OCI labels on the network
     ///
@@ -108,7 +108,7 @@ pub struct Create {
     ///
     /// Can be specified multiple times
     #[arg(long, value_name = "KEY=VALUE")]
-    label: Vec<String>,
+    pub label: Vec<String>,
 
     /// Set driver specific options
     ///
@@ -116,7 +116,7 @@ pub struct Create {
     ///
     /// Can be specified multiple times
     #[arg(short, long, value_name = "OPTION", value_delimiter = ',')]
-    opt: Vec<String>,
+    pub opt: Vec<String>,
 
     /// The subnet in CIDR notation
     ///
@@ -124,17 +124,17 @@ pub struct Create {
     ///
     /// Can be specified multiple times
     #[arg(long)]
-    subnet: Vec<IpNet>,
+    pub subnet: Vec<IpNet>,
 
     /// Converts to "PodmanArgs=ARGS"
     #[command(flatten)]
-    podman_args: PodmanArgs,
+    pub podman_args: PodmanArgs,
 
     /// The name of the network to create
     ///
     /// This will be used as the name of the generated file when used with
     /// the --file option without a filename
-    name: String,
+    pub name: String,
 }
 
 impl From<Create> for crate::quadlet::Network {
@@ -159,18 +159,18 @@ impl From<Create> for crate::quadlet::Network {
 
 #[derive(Args, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "kebab-case")]
-struct PodmanArgs {
+pub struct PodmanArgs {
     /// Maps to the `network_interface` option in the network config
     #[arg(long, value_name = "NAME")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    interface_name: Option<String>,
+    pub interface_name: Option<String>,
 
     /// A static route to add to every container in this network
     ///
     /// Can be specified multiple times
     #[arg(long)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    route: Vec<String>,
+    pub route: Vec<String>,
 }
 
 impl Display for PodmanArgs {

--- a/src/cli/volume.rs
+++ b/src/cli/volume.rs
@@ -2,7 +2,7 @@ pub mod opt;
 
 use clap::{Args, Subcommand};
 
-use self::opt::Opt;
+pub use self::opt::Opt;
 
 #[derive(Subcommand, Debug, Clone, PartialEq)]
 pub enum Volume {
@@ -46,7 +46,7 @@ pub struct Create {
     ///
     /// Converts to "PodmanArgs=--driver DRIVER"
     #[arg(short, long)]
-    driver: Option<String>,
+    pub driver: Option<String>,
 
     /// Set driver specific options
     ///
@@ -64,7 +64,7 @@ pub struct Create {
     ///
     /// Can be specified multiple times
     #[arg(short, long, value_name = "OPTION")]
-    opt: Vec<Opt>,
+    pub opt: Vec<Opt>,
 
     /// Set one or more OCI labels on the volume
     ///
@@ -72,13 +72,13 @@ pub struct Create {
     ///
     /// Can be specified multiple times
     #[arg(short, long, value_name = "KEY=VALUE")]
-    label: Vec<String>,
+    pub label: Vec<String>,
 
     /// The name of the volume to create
     ///
     /// This will be used as the name of the generated file when used with
     /// the --file option without a filename
-    name: String,
+    pub name: String,
 }
 
 impl From<Create> for crate::quadlet::Volume {

--- a/src/quadlet.rs
+++ b/src/quadlet.rs
@@ -16,7 +16,7 @@ pub use self::{
     container::{Container, PullPolicy, Unmask},
     install::Install,
     kube::{AutoUpdate as KubeAutoUpdate, Kube},
-    network::Network,
+    network::{IpRange, Network},
     volume::Volume,
 };
 use crate::cli::{service::Service, unit::Unit};


### PR DESCRIPTION
Closes #23

Adds the `podlet generate` command for generating container, network, or volume quadlets from an existing resource. Similar to the `podman generate` commands.