### PR TITLE
Readme container doc: Also use z suffix for directories too

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,13 +285,13 @@ While podlet can be used as-is in a container, passing the command to it; if you
 
 An example of a generic podman command that runs the most up-to-date version of podlet with the current directory and user's quadlet directory attached to the container would be:
 
-`podman run --rm -v $PWD:$PWD -v $HOME/.config/containers/systemd/:$HOME/.config/containers/systemd/ -w $PWD --security-opt label=disable --pull=newer quay.io/k9withabone/podlet`
-
-Please note that `--security-opt label=disable` may be required for systems with SELinux. If your system does not use SELinux this may not be required.
+`podman run --rm -v $PWD:$PWD:Z -v $HOME/.config/containers/systemd/:$HOME/.config/containers/systemd/:Z -w $PWD --pull=newer quay.io/k9withabone/podlet`
 
 Alternatively, if you just want podlet to read a specific compose file you can use:
 
 `podman run --rm -v ./compose.yaml:/compose.yaml:Z quay.io/k9withabone/podlet compose /compose.yaml`
+
+Please note that the `:Z` suffix may be required for systems with SELinux. If your system does not use SELinux this may not be required.
 
 ## Cautions
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ While podlet can be used as-is in a container, passing the command to it; if you
 
 An example of a generic podman command that runs the most up-to-date version of podlet with the current directory and user's quadlet directory attached to the container would be:
 
-`podman run --rm -v $PWD:$PWD -v $HOME/.config/containers/systemd/:/usr/share/containers/systemd/ -w $PWD --security-opt label=disable --pull=newer quay.io/k9withabone/podlet`
+`podman run --rm -v $PWD:$PWD -v $HOME/.config/containers/systemd/:$HOME/.config/containers/systemd/ -w $PWD --security-opt label=disable --pull=newer quay.io/k9withabone/podlet`
 
 Please note that `--security-opt label=disable` may be required for systems with SELinux. If your system does not use SELinux this may not be required.
 


### PR DESCRIPTION
You suggest to disable SELinux completely for that feature. However the [`:Z` suffix](https://unix.stackexchange.com/questions/651198/podman-volume-mounts-when-to-use-the-z-or-z-suffix) can also be used for directories, so there is no need for `--security-opt label=disable`.

I've tested the provided command (with Fedora CoreOS, which uses SELinux – also tested it fails without the Z) and it properly detected an existing file and warned from overwriting and could also write a new file. So it works.

(used #50 as a base for that to not get merge conflicts)