### PR TITLE
allow specifying both image and build

### DIFF
--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -260,34 +260,37 @@ impl From<Build> for quadlet::Resource {
     }
 }
 
-impl TryFrom<service::Build> for Build {
+impl TryFrom<(service::Build, Option<service::Image>)> for Build {
     type Error = color_eyre::Report;
 
     fn try_from(
-        service::Build {
-            context,
-            dockerfile,
-            args,
-            ssh,
-            cache_from,
-            cache_to,
-            additional_contexts,
-            entitlements,
-            extra_hosts,
-            isolation,
-            privileged,
-            labels,
-            no_cache,
-            pull,
-            network,
-            shm_size,
-            target,
-            secrets,
-            tags,
-            ulimits,
-            platforms,
-            extensions,
-        }: service::Build,
+        (
+            service::Build {
+                context,
+                dockerfile,
+                args,
+                ssh,
+                cache_from,
+                cache_to,
+                additional_contexts,
+                entitlements,
+                extra_hosts,
+                isolation,
+                privileged,
+                labels,
+                no_cache,
+                pull,
+                network,
+                shm_size,
+                target,
+                secrets,
+                tags,
+                ulimits,
+                platforms,
+                extensions,
+            },
+            image,
+        ): (service::Build, Option<service::Image>),
     ) -> Result<Self, Self::Error> {
         ensure!(entitlements.is_empty(), "`entitlements` are not supported");
         ensure!(!privileged, "`privileged` is not supported");
@@ -356,8 +359,8 @@ impl TryFrom<service::Build> for Build {
         };
 
         let mut tags = tags.into_iter();
-        let tag = tags
-            .next()
+        let tag = image
+            .or_else(|| tags.next())
             .ok_or_eyre("an image tag is required")?
             .into_inner();
         ensure!(

--- a/src/cli/compose.rs
+++ b/src/cli/compose.rs
@@ -323,15 +323,9 @@ fn services_try_into_quadlet_files<'a>(
     pod_ports: &'a mut Vec<String>,
 ) -> impl Iterator<Item = color_eyre::Result<quadlet::File>> + 'a {
     services.into_iter().flat_map(move |(name, mut service)| {
-        if service.image.is_some() && service.build.is_some() {
-            return iter::once(Err(eyre!(
-                "error converting service `{name}`: `image` and `build` cannot both be set"
-            )))
-            .chain(None);
-        }
-
         let build = service.build.take().map(|build| {
-            let build = Build::try_from(build.into_long()).wrap_err_with(|| {
+            let image = service.image.take();
+            let build = Build::try_from((build.into_long(), image)).wrap_err_with(|| {
                 format!(
                     "error converting `build` for service `{name}` into a Quadlet `.build` file"
                 )


### PR DESCRIPTION
if `image` is specified, use it as tag
otherwise use the first value from `build.tags`
then fail if any tags exist beyond that

it might be worth checking if `image` value is equal to first value from `build.tags` and still allow that, or go even further and fail only if there exist 2 distinct values that could be used as tags
not sure if that's too niche to include, please lmk