### PR TITLE
Add Podman v5.8.2 compatibility

### DIFF
--- a/src/quadlet.rs
+++ b/src/quadlet.rs
@@ -649,7 +649,7 @@ pub enum PodmanVersion {
     V5_7,
 
     /// Podman v5.8
-    #[value(name = "5.8", aliases = ["latest", "5.8.0", "5.8.1"])]
+    #[value(name = "5.8", aliases = ["latest", "5.8.0", "5.8.1", "5.8.2"])]
     V5_8,
 }
 


### PR DESCRIPTION
Podman v5.8.2 has been [released](https://github.com/containers/podman/releases/tag/v5.8.2) and needs to be added to the supported Podman versions.

Fixes #209