### PR TITLE
Update security policy

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,7 @@
 # Podlet Maintainers
 
 Podlet is a community project maintained by volunteers. They may be contacted directly in case of a security vulnerability.
-However, if possible, please use the [private security vulnerability reporting](https://github.com/containers/podlet/security) on GitHub.
+However, if possible, please use GitHub's private security vulnerability reporting feature by pressing the "Report a vulnerability" button on the repository's [security](https://github.com/containers/podlet/security) page.
 For all other communication, please use one of the [communication channels](./README.md#Communication).
 
 | Maintainer     | Project Role         | GitHub                                          | Matrix                              | Discord                  | Email                                                                         |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,10 @@
+# Podlet Maintainers
+
+Podlet is a community project maintained by volunteers. They may be contacted directly in case of a security vulnerability.
+However, if possible, please use the [private security vulnerability reporting](https://github.com/containers/podlet/security) on GitHub.
+For all other communication, please use one of the [communication channels](./README.md#Communication).
+
+| Maintainer     | Project Role         | GitHub                                          | Matrix                              | Discord                  | Email                                                                         |
+| -------------- | -------------------- | ----------------------------------------------- | ----------------------------------- | ------------------------ | ----------------------------------------------------------------------------- |
+| Paul Nettleton | Maintainer (Creator) | [k9withabone](https://github.com/k9withabone)   | @k9withabone:matrix.org (Preferred) | k9withabone              | [k9@k9withabone.dev](mailto:k9@k9withabone.dev)                               |
+| Martin Beckert | Maintainer           | [TheRealBecks](https://github.com/TheRealBecks) |                                     | therealbecks (Preferred) | [martin.beckert@strukturpiloten.de](mailto:martin.beckert@strukturpiloten.de) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,9 +3,10 @@
 ## Reporting a Vulnerability
 
 If you have identified a security vulnerability in the Podlet project, please **do not** report the
-issue publicly via GitHub issues, mailing list, Discord, etc. Instead, use the
-[private security vulnerability reporting](https://github.com/containers/podlet/security) on GitHub
-or privately contact one or more of the [maintainers](./MAINTAINERS.md).
+issue publicly via GitHub issues, mailing list, Discord, etc. Instead, use GitHub's private
+security vulnerability reporting feature by pressing the "Report a vulnerability" button on the
+repository's [security](https://github.com/containers/podlet/security) page or privately contact one
+or more of the [maintainers](./MAINTAINERS.md).
 
 ## Security Announcements
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,21 @@
-## Security and Disclosure Information Policy for the Podlet Project
+# Security and Disclosure Information Policy for the Podlet Project
 
-The Podlet project follows the [Security and Disclosure Information Policy](https://github.com/containers/common/blob/main/SECURITY.md) for the Containers Projects.
+## Reporting a Vulnerability
+
+If you have identified a security vulnerability in the Podlet project, please **do not** report the
+issue publicly via GitHub issues, mailing list, Discord, etc. Instead, use the
+[private security vulnerability reporting](https://github.com/containers/podlet/security) on GitHub
+or privately contact one or more of the [maintainers](./MAINTAINERS.md).
+
+## Security Announcements
+
+All security vulnerabilities will be disclosed in the next
+[release](https://github.com/containers/podlet/releases) after they are fixed.
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed as soon as is practicable given that Podlet is maintained
+by a few volunteers.
+
+As the security report moves toward an identified fix and release, the maintainers will keep the
+reporter updated.


### PR DESCRIPTION
Added `MAINTAINERS.md` with contact information for the Podlet maintainers.

Changed `SECURITY.md` to direct security vulnerability reports to the Podlet maintainers.

Closes: #183